### PR TITLE
Add logout method for local storage

### DIFF
--- a/oauth2/oauth2.js
+++ b/oauth2/oauth2.js
@@ -475,7 +475,7 @@
 			// log the user out
 			// remove all auth info in local storage for the given prefix
 			var defaultOptions = {
-				localStoragePrefix: "oauth2.signupapp."
+				localStoragePrefix: "oauth2."
 			}
 			var opts = _.extend({}, defaultOptions, options || {});
 			localStorage.removeItem(opts.localStoragePrefix + accessTokenParamName);

--- a/oauth2/oauth2.js
+++ b/oauth2/oauth2.js
@@ -27,6 +27,10 @@
 (function() {
 	var authorizationResponseEventName = 'oauth2-authorization-response';
 	var requiredOptions = ['clientID', 'clientSecret', 'authorizeEndpoint', 'tokenEndpoint'];
+	var accessTokenParamName = 'access-token';
+	var refreshTokenParamName = 'refresh-token';
+	var accessTokenExpiryParamName = 'access-token-expiry';
+	var authMechanismParamName = 'auth-mechanism';
 
 	var OAuth2XMLHttpRequest = function (options) {
 		for (var i=0; i<requiredOptions.length; i++)
@@ -37,10 +41,10 @@
 		this._openArguments = null;
 		this._sendArguments = null;
 		this._options = _.extend({}, this._defaultOptions, options || {});
-		this._accessTokenParamName = this._options.localStoragePrefix+'access-token';
-		this._refreshTokenParamName = this._options.localStoragePrefix+'refresh-token';
-		this._accessTokenExpiryParamName = this._options.localStoragePrefix+'access-token-expiry';
-		this._authMechanismParamName = this._options.localStoragePrefix+'auth-mechanism';
+		this._accessTokenParamName = this._options.localStoragePrefix+accessTokenParamName;
+		this._refreshTokenParamName = this._options.localStoragePrefix+refreshTokenParamName;
+		this._accessTokenExpiryParamName = this._options.localStoragePrefix+accessTokenExpiryParamName;
+		this._authMechanismParamName = this._options.localStoragePrefix+authMechanismParamName;
 		this._authorizationWindow = null;
 		this._instantiateXHR();
 		this._replaying = false;
@@ -466,6 +470,19 @@
 					console.log("Origins don't match; not passing on code.");
 				}
 			}
+		},
+		logout: function (options) {
+			// log the user out
+			// remove all auth info in local storage for the given prefix
+			var defaultOptions = {
+				localStoragePrefix: "oauth2.signupapp."
+			}
+			var opts = _.extend({}, defaultOptions, options || {});
+			localStorage.removeItem(opts.localStoragePrefix + accessTokenParamName);
+			localStorage.removeItem(opts.localStoragePrefix + refreshTokenParamName);
+			localStorage.removeItem(opts.localStoragePrefix + accessTokenExpiryParamName);
+			localStorage.removeItem(opts.localStoragePrefix + authMechanismParamName);
+
 		}
 	};
 

--- a/oauth2/oauth2.js
+++ b/oauth2/oauth2.js
@@ -31,7 +31,7 @@
 	var refreshTokenParamName = 'refresh-token';
 	var accessTokenExpiryParamName = 'access-token-expiry';
 	var authMechanismParamName = 'auth-mechanism';
-	var localStoragePrefix = 'oauth2.';
+	var defaultLocalStoragePrefix = 'oauth2.';
 
 	var OAuth2XMLHttpRequest = function (options) {
 		for (var i=0; i<requiredOptions.length; i++)
@@ -74,7 +74,7 @@
 		supportsCORS: window.XDomainRequest != undefined || "withCredentials" in XMLHttpRequest,
 		// Override to ask user for permission before calling authorize()
 		requestAuthorization: function(authorize) { authorize(); },
-		localStoragePrefix: localStoragePrefix,
+		localStoragePrefix: defaultLocalStoragePrefix,
 		error: function(type, data) { console.log(["OAuth2 error", type, data]); },
 		redirectURI: window.location.toString(),
 		// Override to use a different name for the WWW-Authenticate header (necessary for cordova on iOS)
@@ -476,7 +476,7 @@
 			// log the user out
 			// remove all auth info in local storage for the given prefix
 			var defaultOptions = {
-				localStoragePrefix: localStoragePrefix
+				localStoragePrefix: defaultLocalStoragePrefix
 			}
 			var opts = _.extend({}, defaultOptions, options || {});
 			localStorage.removeItem(opts.localStoragePrefix + accessTokenParamName);

--- a/oauth2/oauth2.js
+++ b/oauth2/oauth2.js
@@ -31,6 +31,7 @@
 	var refreshTokenParamName = 'refresh-token';
 	var accessTokenExpiryParamName = 'access-token-expiry';
 	var authMechanismParamName = 'auth-mechanism';
+	var localStoragePrefix = 'oauth2.';
 
 	var OAuth2XMLHttpRequest = function (options) {
 		for (var i=0; i<requiredOptions.length; i++)
@@ -73,7 +74,7 @@
 		supportsCORS: window.XDomainRequest != undefined || "withCredentials" in XMLHttpRequest,
 		// Override to ask user for permission before calling authorize()
 		requestAuthorization: function(authorize) { authorize(); },
-		localStoragePrefix: 'oauth2.',
+		localStoragePrefix: localStoragePrefix,
 		error: function(type, data) { console.log(["OAuth2 error", type, data]); },
 		redirectURI: window.location.toString(),
 		// Override to use a different name for the WWW-Authenticate header (necessary for cordova on iOS)
@@ -475,7 +476,7 @@
 			// log the user out
 			// remove all auth info in local storage for the given prefix
 			var defaultOptions = {
-				localStoragePrefix: "oauth2."
+				localStoragePrefix: localStoragePrefix
 			}
 			var opts = _.extend({}, defaultOptions, options || {});
 			localStorage.removeItem(opts.localStoragePrefix + accessTokenParamName);


### PR DESCRIPTION
Adds a logout method to the window object, which requires the user to pass in the desired local storage prefix as an option.

Not quite as elegant a solution as I'd like, but works ok.
